### PR TITLE
Corrected HTTP status code to verify file deletion

### DIFF
--- a/lib/paperclip/storage/google_drive.rb
+++ b/lib/paperclip/storage/google_drive.rb
@@ -91,7 +91,7 @@ module Paperclip
             result = client.execute(
               :api_method => drive.files.delete,
               :parameters => parameters)
-            if result.status != 200
+            if result.status != 204
               puts "An error occurred: #{result.data['error']['message']}"
             end
           end


### PR DESCRIPTION
Google seems to have silently changed their APIs to return HTTP status code 204 (No Content) instead of 200 (OK). Their own demo page does not reflect the change in the sample code, however their demo exposes the new 204 code when executed. 

Other Google APIs are documented to return status 204 upon deleting an item, which leads me to think Google simply forgot about updating documentation for Drive.