### PR TITLE
Improve file lookups & support long filenames

### DIFF
--- a/lib/paperclip/storage/google_drive.rb
+++ b/lib/paperclip/storage/google_drive.rb
@@ -156,7 +156,7 @@ module Paperclip
       def search_for_title(title)
         parameters = {
                 'folderId' => find_public_folder,
-                'q' => "title contains '#{title}'", # full_title
+                'q' => "title = '#{title}'", # full_title
                 'fields' => 'items/id'}
         client = google_api_client
         drive = client.discovered_api('drive', 'v2')

--- a/lib/paperclip/storage/google_drive.rb
+++ b/lib/paperclip/storage/google_drive.rb
@@ -143,7 +143,7 @@ module Paperclip
         end
       end # full title
 
-      def public_url_for title
+      def public_url_for(title)
         searched_id = search_for_title(title) #return id if any or style
         if searched_id.nil? # it finds some file
           default_image


### PR DESCRIPTION
Currently, files are queried for using the "contains" method. A better method is "=", therefore querying for the exact filename. This also fixes a bug (possibly related to #5?) where files with long filenames cannot be looked up.

@evinsou Could you please look over this, among other, pull requests? This and #8 are relatively important to the stability of the gem.

In the unfortunate event this gem can't get any further support, I do have a functional fork at https://github.com/sman591/paperclip-googledrive that'll be in active use at least for the next few months if anyone else is interested.