### PR TITLE
Update dependencies

### DIFF
--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,3 +1,3 @@
 module PaperclipGoogleDrive
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/paperclip-googledrive.gemspec
+++ b/paperclip-googledrive.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.require_paths = ["lib"]
-  gem.required_ruby_version = ">= 1.9.2"
+  gem.required_ruby_version = ">= 2.0.0"
   gem.license       = "MIT"
 
-  gem.add_dependency "paperclip", "~> 3.4"
+  gem.add_dependency "paperclip", ">= 3.4"
   gem.add_dependency 'google-api-client', "~> 0.5"
 
   gem.add_development_dependency "rake", ">= 0.9"


### PR DESCRIPTION
Ruby [1.9.3 is no longer supported](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/).

Targeting paperclip to explicitly use `3.4` was causing issues with Rails 4.2.  After this fix and a `bundle update paperclip` everything worked (using paperclip 4.2.1).