### PR TITLE
Expanded instructions on setting up the Google API project correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,25 @@ Or install it yourself as:
 
 ## Google Drive Setup
 
-Google Drive is a free service for file storage files. In order to use this storage you have to create oauth 2.0 client in [Google APIs console](https://code.google.com/apis/console/) and authorize access to Google Drive account.
+Google Drive is a free service for file storage files. In order to use this storage you need a Google (or Google Apps) user which will own the files, and a Google API client.
 
-After creating your app, it will have an Client ID, Client Secret, Redirect URL. Get auth scope for drive [Google Drive scopes](https://developers.google.com/drive/scopes). You need these for the authorization Rake task:
-```
-$ rake google_drive:authorize
-```
-When you call this Rake task, it will ask you to provide the client id, client secret, redirect url and auth scope. Afterwards it will present you with an authorize url on Google Drive. Simply go to that url, authorize the app, then enter code from url in the console. The rake task will output valid ruby code which you can use to create a client.
+1. Go to the [Google Developers console](https://console.developers.google.com/project) and create a new project.
+
+2. Go to "APIs & Auth > APIs" and enable "Drive API". If you are getting an "Access Not Configured" error while uploading files, this is due to this API not being enabled.
+
+3. Go to "APIs & Auth > Credentials" and create a new OAuth 2.0 Client ID; select "web application" type, specify `http://localhost` for application home page.
+
+4. Now you will have a Client ID, Client Secret, and Redirect URL. 
+
+5. Run the authorization task:
+    ```
+    $ rake google_drive:authorize
+    ```
+    When you call this Rake task, it will ask you to provide the client id, client secret, redirect url and auth scope. Specify `https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/userinfo.profile` for scope ([more on Google Drive scopes](https://developers.google.com/drive/scopes)). 
+
+6. The Rake task will give you an auth url. Simply go to that url (while signed in as the designated uploads owner), authorize the app, then enter code from url in the console. The rake task will output valid ruby code which you can use to create a client, in particular, the access and refresh tokens.
+
+7. Create a folder in which the files will be uploaded; note the folder's ID.
 
 ## Configuration
 


### PR DESCRIPTION
The instructions on setting up were a bit vague, and we had to figure out specifics on our own, so I wanted to clarify the steps needed, in particular what API must be enabled and what scopes does the API user need.